### PR TITLE
COMPASS-933 Add tests and remove 'test' regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ function NS(ns) {
     this.collection = ns.slice(this.dotIndex + 1);
   }
 
-  if (/\.(count|time)$/.test(this.collection)) {
-    var matches = /\.([a-z]+)\.(count|time)$/.exec(this.collection);
+  var matches = /\.([a-z]+)\.(count|time)$/.exec(this.collection);
+  if (matches) {
     this.collection = this.collection.slice(0, matches.index);
     this.metric = matches[1];
     this.metricType = matches[2];

--- a/test.js
+++ b/test.js
@@ -200,6 +200,22 @@ describe('ns', function() {
       assert.equal(ns('canadian-things.foods.read.count').metric, 'read');
       assert.equal(ns('canadian-things.foods.read.count').metricType, 'count');
     });
+
+    context('triggered a TypeError', function() {
+      // TypeError: Cannot read property 'index' of null
+      it('uppercase', function() {
+        assert.equal(ns('FOO.BAR.count').metric, null);
+        assert.equal(ns('FOO.BAR.count').metricType, null);
+      });
+      it('pure numbers or dates', function() {
+        assert.equal(ns('2017-01-01.12-34-56.count').metric, null);
+        assert.equal(ns('2017-01-01.12-34-56.count').metricType, null);
+      });
+      it('special characters like ü', function() {
+        assert.equal(ns('ü.ü.count').metric, null);
+        assert.equal(ns('ü.ü.count').metricType, null);
+      });
+    });
   });
 
   describe('sorting', function() {


### PR DESCRIPTION
Resolves "TypeError: Cannot read property 'index' of null".

Reusing the 'exec' regex is the simplest fix that I think could possibly work, though I am unsure about how graphite would be expected to handle collections composed of dates or characters that are uppercase or alphabetical.

Related:
http://graphite.readthedocs.io/en/latest/terminology.html
https://docs.mongodb.com/manual/reference/limits/#faq-restrictions-on-collection-names

## Testing

### BEFORE

Compass hangs and reports the error in a system error notification:

<img width="1282" alt="reproduced before" src="https://cloud.githubusercontent.com/assets/1217010/26611752/9db850fa-45f3-11e7-9593-84d5b272e15c.png">

### AFTER

Compass lists the new collections (note Compass sidebar hides metrics collections like `foo.bar.read.time`, which I assume is by design of this namespace module):

<img width="513" alt="after" src="https://cloud.githubusercontent.com/assets/1217010/26611798/0dbc0a68-45f4-11e7-94ff-21b597319a7c.png">
