### PR TITLE
COMPASS-1209 Remove metrics handling code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,12 @@ var ns = require('mongodb-ns');
 
 var bacon = ns('canadian-things.songs-aboot-bacon');
 console.log(bacon.toString(), bacon);
-
-// knows how to handle graphite-style metrics to boot
-var maple = ns('canadian-things.maple-based-fabrics.read.time');
-console.log(maple.toString(), maple);
 ```
 
 will output
 
 ```
-canadian-things.songs-aboot-bacon {
+canadian-things.songs-aboot-bacon NS {
   ns: 'canadian-things.songs-aboot-bacon',
   dotIndex: 15,
   database: 'canadian-things',
@@ -27,28 +23,11 @@ canadian-things.songs-aboot-bacon {
   oplog: false,
   command: false,
   special: false,
+  specialish: false,
   normal: true,
   validDatabaseName: true,
   validCollectionName: true,
-  databaseHash: 23620443216
-}
-
-canadian-things.maple-based-fabrics.read.time {
-  ns: 'canadian-things.maple-based-fabrics.read.time',
-  dotIndex: 15,
-  database: 'canadian-things',
-  collection: 'maple-based-fabrics',
-  metric: 'read',
-  metricType: 'time',
-  system: false,
-  oplog: false,
-  command: false,
-  special: false,
-  normal: true,
-  validDatabaseName: true,
-  validCollectionName: true,
-  databaseHash: 23620443216
-}
+  databaseHash: 23620443216 }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Handle dem namespaces like the kernel do.
 var ns = require('mongodb-ns');
 
 var bacon = ns('canadian-things.songs-aboot-bacon');
-console.log(bacon.toString(), bacon);
+console.log(bacon.toString() + '\n', bacon);
 ```
 
 will output
 
 ```
-canadian-things.songs-aboot-bacon NS {
+canadian-things.songs-aboot-bacon
+ NS {
   ns: 'canadian-things.songs-aboot-bacon',
   dotIndex: 15,
   database: 'canadian-things',

--- a/index.js
+++ b/index.js
@@ -22,13 +22,6 @@ function NS(ns) {
     this.collection = ns.slice(this.dotIndex + 1);
   }
 
-  var matches = /\.([a-z]+)\.(count|time)$/.exec(this.collection);
-  if (matches) {
-    this.collection = this.collection.slice(0, matches.index);
-    this.metric = matches[1];
-    this.metricType = matches[2];
-  }
-
   this.system = /^system\./.test(this.collection);
   this.oplog = /local\.oplog\.(\$main|rs)/.test(ns);
 
@@ -60,9 +53,6 @@ function NS(ns) {
     return true;
   }.bind(this));
 }
-
-NS.prototype.metric = null;
-NS.prototype.metricType = null;
 
 NS.prototype.database = '';
 NS.prototype.databaseHash = 0;

--- a/test.js
+++ b/test.js
@@ -190,30 +190,30 @@ describe('ns', function() {
 
   describe('metric', function() {
     it('should default to null if not a metric namespace', function() {
-      assert.equal(ns('canadian-things.foods').metric, null);
+      assert.equal(ns('canadian-things.foods').metric, undefined);
     });
     it('should allow only `count` and `time` types', function() {
-      assert.equal(ns('canadian-things.foods.read.microseconds').metric, null);
+      assert.equal(ns('canadian-things.foods.read.microseconds').metric, undefined);
     });
 
-    it('should pluck the name and type of a valid metric', function() {
-      assert.equal(ns('canadian-things.foods.read.count').metric, 'read');
-      assert.equal(ns('canadian-things.foods.read.count').metricType, 'count');
+    it('should no longer pluck the name and type of a valid metric', function() {
+      assert.equal(ns('canadian-things.foods.read.count').metric, undefined);
+      assert.equal(ns('canadian-things.foods.read.count').metricType, undefined);
     });
 
     context('triggered a TypeError', function() {
       // TypeError: Cannot read property 'index' of null
       it('uppercase', function() {
-        assert.equal(ns('FOO.BAR.count').metric, null);
-        assert.equal(ns('FOO.BAR.count').metricType, null);
+        assert.equal(ns('FOO.BAR.count').metric, undefined);
+        assert.equal(ns('FOO.BAR.count').metricType, undefined);
       });
       it('pure numbers or dates', function() {
-        assert.equal(ns('2017-01-01.12-34-56.count').metric, null);
-        assert.equal(ns('2017-01-01.12-34-56.count').metricType, null);
+        assert.equal(ns('2017-01-01.12-34-56.count').metric, undefined);
+        assert.equal(ns('2017-01-01.12-34-56.count').metricType, undefined);
       });
       it('special characters like ü', function() {
-        assert.equal(ns('ü.ü.count').metric, null);
-        assert.equal(ns('ü.ü.count').metricType, null);
+        assert.equal(ns('ü.ü.count').metric, undefined);
+        assert.equal(ns('ü.ü.count').metricType, undefined);
       });
     });
   });

--- a/test.js
+++ b/test.js
@@ -188,36 +188,6 @@ describe('ns', function() {
     assert.equal(ns('abc.').database, 'abc');
   });
 
-  describe('metric', function() {
-    it('should default to null if not a metric namespace', function() {
-      assert.equal(ns('canadian-things.foods').metric, undefined);
-    });
-    it('should allow only `count` and `time` types', function() {
-      assert.equal(ns('canadian-things.foods.read.microseconds').metric, undefined);
-    });
-
-    it('should no longer pluck the name and type of a valid metric', function() {
-      assert.equal(ns('canadian-things.foods.read.count').metric, undefined);
-      assert.equal(ns('canadian-things.foods.read.count').metricType, undefined);
-    });
-
-    context('triggered a TypeError', function() {
-      // TypeError: Cannot read property 'index' of null
-      it('uppercase', function() {
-        assert.equal(ns('FOO.BAR.count').metric, undefined);
-        assert.equal(ns('FOO.BAR.count').metricType, undefined);
-      });
-      it('pure numbers or dates', function() {
-        assert.equal(ns('2017-01-01.12-34-56.count').metric, undefined);
-        assert.equal(ns('2017-01-01.12-34-56.count').metricType, undefined);
-      });
-      it('special characters like ü', function() {
-        assert.equal(ns('ü.ü.count').metric, undefined);
-        assert.equal(ns('ü.ü.count').metricType, undefined);
-      });
-    });
-  });
-
   describe('sorting', function() {
     it('should sort them', function() {
       var names = ['admin', 'canadian-things', 'github', 'local', 'scope_stat', 'statsd', 'test'];


### PR DESCRIPTION
It means in Compass that if one tries to create say the collection `BAR.read.time` on any database, they instead create the collection `BAR`, which I think is [surprising](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).
